### PR TITLE
Make custom template names possible

### DIFF
--- a/tasks/dustjs.js
+++ b/tasks/dustjs.js
@@ -15,13 +15,13 @@ module.exports = function (grunt) {
   var normalizeMultiTaskFiles = function(data, target) {
     var prop, obj;
     var files = [];
-    if (grunt.util.kindOf(data) === 'object') {
+    if (grunt.utils.kindOf(data) === 'object') {
       if ('src' in data || 'dest' in data) {
         obj = {};
         if ('src' in data) { obj.src = data.src; }
         if ('dest' in data) { obj.dest = data.dest; }
         files.push(obj);
-      } else if (grunt.util.kindOf(data.files) === 'object') {
+      } else if (grunt.utils.kindOf(data.files) === 'object') {
         for (prop in data.files) {
           files.push({src: data.files[prop], dest: prop});
         }
@@ -45,7 +45,7 @@ module.exports = function (grunt) {
     files.forEach(function(obj) {
       // Process src as a template (recursively, if necessary).
       if ('src' in obj) {
-        obj.src = grunt.util.recurse(obj.src, function(src) {
+        obj.src = grunt.utils.recurse(obj.src, function(src) {
           if (typeof src !== 'string') { return src; }
           return grunt.template.process(src);
         });
@@ -89,7 +89,7 @@ module.exports = function (grunt) {
 
     try {
       var name;
-     if (typeof fullFilename === "function") {
+      if (typeof fullFilename === "function") {
         name = fullFilename(filepath);
       } else if (fullFilename) {
         name = filepath;


### PR DESCRIPTION
I added the option to configure the fullname option as a function so you can use custom template name formatters in your grunt script.

e.g.

``` javascript
{
  'templates/compiled/all.js': ['templates/all/**/*.html'],
  options: {
    fullname: function(filepath) {
       return path.relative('templates/all', path.dirname(filepath)).split(path.sep) // folder names
         .concat([path.basename(filepath, path.extname(filepath))]) // template name
         .join('.');
    }
  }
}
```

would deliver

``` javascript
[
  'main.index',
  'main.sidebar',
  'partials.header',
  'partials.footer'
]
```
