### PR TITLE
Allow usage of new Grunt 0.4 files syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,23 @@ Then add this line to your project's `grunt.js` gruntfile:
 grunt.loadNpmTasks('grunt-dustjs');
 ```
 
-[npm_registry_page]: http://search.npmjs.org/#/grunt-dustjs
-[grunt]: https://github.com/cowboy/grunt
-[getting_started]: https://github.com/cowboy/grunt/blob/master/docs/getting_started.md
+[getting_started]: https://github.com/gruntjs/grunt/wiki/Getting-started
+[grunt]: http://gruntjs.com
 
 Documentation
 =============
 
-Inside your `grunt.js` file, add a section named `dustjs`. This section specifies the Dust.js template files to compile.
+Inside your `grunt.js` file, add a section named `dustjs` with one or more targets. Each section contains a files object that specifies the Dust.js template files to compile.
 
-##### files ```object```
+##### `files` object
 
-This defines what files this task will process and should contain key:value pairs.
+This defines what files this task will process. It can contain any valid Grunt files format.
 
-The key (destination) should be an unique filepath (supports [grunt.template](https://github.com/cowboy/grunt/blob/master/docs/api_template.md)) and the value (source) should be a filepath or an array of filepaths (supports [minimatch](https://github.com/isaacs/minimatch)).
+When using a src/dest format, the key (destination) should be an unique filepath (supports [grunt.template](https://github.com/gruntjs/grunt/wiki/grunt.template)) and the value (source) should be a filepath or an array of filepaths (supports [minimatch](https://github.com/isaacs/minimatch)). All source files will be combined into the destination output.
 
-Also, you can use `fullname` option to customize template variable name.
+When using the dynamic format (example #3), each source file will be processed into its own destination file.
+
+Also, you can use `fullname` option to customize the template variable names. If `fullname` is `true`, the full path will be used as the template name. If `fullname` is a function, the function receives a single argument, which is the full path, and returns the name of the template.
 
 ### Example #1
 
@@ -65,6 +66,28 @@ grunt.initConfig({
       }
     }
   },
+});
+```
+
+
+### Example #3 (one JS file per template)
+
+```javascript
+// project configuration
+grunt.initConfig({
+  dustjs: {
+    compile: {
+      files: [
+        {
+          expand: true,
+          cwd: "dust/",
+          src: "**/*.html",
+          dest: "",
+          ext: ".js"
+        }
+      ]
+    }
+  }
 });
 ```
 

--- a/bin/grunt-dustjs
+++ b/bin/grunt-dustjs
@@ -1,2 +1,2 @@
 #!/usr/bin/env node
-require('grunt').npmTasks('grunt-dustjs').cli();
+require('grunt').loadNpmTasks('grunt-dustjs').cli();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt": "~0.4.0rc5",
+    "grunt": "~0.4.0",
     "dustjs-linkedin": ">= 1.0.0"
   },
   "devDependencies": {

--- a/tasks/dustjs.js
+++ b/tasks/dustjs.js
@@ -11,104 +11,55 @@
 module.exports = function (grunt) {
   "use strict";
 
-  // Temporary helper for normalizing files object
-  var normalizeMultiTaskFiles = function(data, target) {
-    var prop, obj;
-    var files = [];
-    if (grunt.util.kindOf(data) === 'object') {
-      if ('src' in data || 'dest' in data) {
-        obj = {};
-        if ('src' in data) { obj.src = data.src; }
-        if ('dest' in data) { obj.dest = data.dest; }
-        files.push(obj);
-      } else if (grunt.util.kindOf(data.files) === 'object') {
-        for (prop in data.files) {
-          files.push({src: data.files[prop], dest: prop});
-        }
-      } else if (Array.isArray(data.files)) {
-        data.files.forEach(function(obj) {
-          var prop;
-          if ('src' in obj || 'dest' in obj) {
-            files.push(obj);
-          } else {
-            for (prop in obj) {
-              files.push({src: obj[prop], dest: prop});
-            }
-          }
-        });
-      }
-    } else {
-      files.push({src: data, dest: target});
-    }
-
-    // Process each normalized file object as a template.
-    files.forEach(function(obj) {
-      // Process src as a template (recursively, if necessary).
-      if ('src' in obj) {
-        obj.src = grunt.util.recurse(obj.src, function(src) {
-          if (typeof src !== 'string') { return src; }
-          return grunt.template.process(src);
-        });
-      }
-      if ('dest' in obj) {
-        // Process dest as a template.
-        obj.dest = grunt.template.process(obj.dest);
-      }
+  grunt.registerMultiTask("dustjs", "Grunt task to compile Dust.js templates.", function () {
+    // Extend with the default options if none are specified
+    var options = this.options({
+        fullname: false
     });
 
-    return files;
-  };
-
-  var compile;
-
-  grunt.registerMultiTask("dustjs", "Grunt task to compile Dust.js templates.", function () {
-
-    this.files = this.files || normalizeMultiTaskFiles(this.data, this.target);
-
-    var options = this.data.options || {};
-
     this.files.forEach(function (file) {
-      var srcFiles = grunt.file.expand({filter: 'isFile'}, file.src);
-      var taskOutput = [];
+      var srcFiles = grunt.file.expandFiles(file.src),
+          taskOutput = [];
 
       srcFiles.forEach(function (srcFile) {
-        var sourceCode = grunt.file.read(srcFile);
-        var sourceCompiled = compile(sourceCode, srcFile, options.fullname);
+        var sourceCode = grunt.file.read(srcFile),
+            sourceCompiled = compile(sourceCode, srcFile, options.fullname);
 
         taskOutput.push(sourceCompiled);
       });
 
       if (taskOutput.length > 0) {
         grunt.file.write(file.dest, taskOutput.join("\n"));
-        grunt.log.writeln("File '" + file.dest + "' created.");
+        grunt.verbose.writeln("[dustjs] Compiled " + grunt.log.wordlist(srcFiles.toString().split(","), {color: false}) + " => " + file.dest);
+        grunt.verbose.or.writeln("[dustjs] Compiled " + file.dest);
       }
     });
   });
 
-  compile = function (source, filepath, fullFilename) {
-    var path = require("path");
-    var dust = require("dustjs-linkedin");
+  function compile (source, filepath, fullFilename) {
+    var path = require("path"),
+        dust = require("dustjs-linkedin"),
+        name;
 
-    try {
-      var name;
-      if (typeof fullFilename === "function") {
-        name = fullFilename(filepath);
-      } else if (fullFilename) {
-        name = filepath;
-      } else {
-        // Sets the name of the template as the filename without the extension
-        // Example: "fixtures/dust/one.dust" > "one"
-        name = path.basename(filepath, path.extname(filepath));
-      }
-
-      if (name !== undefined) {
-        var output = dust.compile(source, name);
-        return output;
-      }
-      return '';
-    } catch (e) {
-      grunt.log.error(e);
-      grunt.fail.warn("Dust.js failed to compile.");
+    if (typeof fullFilename === "function") {
+      name = fullFilename(filepath);
+    } else if (fullFilename) {
+      name = filepath;
+    } else {
+      // Sets the name of the template as the filename without the extension
+      // Example: "fixtures/dust/one.dust" > "one"
+      name = path.basename(filepath, path.extname(filepath));
     }
-  };
+
+    if (name !== undefined) {
+      try {
+        return dust.compile(source, name);
+      } catch (e) {
+        grunt.log.error(e);
+        grunt.fail.warn("Dust.js failed to compile.");
+      }
+    }
+
+    return '';
+  }
 };


### PR DESCRIPTION
I'd like to add support for the full range of files syntaxes, specifically the dynamic syntax:

http://gruntjs.com/configuring-tasks#building-the-files-object-dynamically

This also allows removal of the temporary normalization helper.

I've verified that all the current examples still work fine and I've added a new example showing the new functionality.

I also took the opportunity to do a bit of README cleanup (broken links) and general touchups.

I did bump the Grunt requirement to 0.4.0 final; that may or may not be what you want. I did not update this package's version as I am unsure of your desired increment.

Thanks very much for maintaining this package!
