### PR TITLE
Add appendSpace option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Used to customize the template variable names. If `fullname` is `true`, the full
 ##### `transformQuote` _default_: `false`
 Used to reverse quotes usage by dustjs: double quotes replaced by single quotes and vice versa. Output is more clean after this transformation.
 
+##### `appendSpace` _default_: `false`
+Append a space on each line of the dust template before compiling. This prevents bugs where the HTML formatter may remove trailing spaces from templates and thus incorrect HTML code.  
+
 ### Example #1
 
 ```javascript

--- a/tasks/dustjs.js
+++ b/tasks/dustjs.js
@@ -16,6 +16,7 @@ module.exports = function (grunt) {
     var options = this.options({
       fullname: false,
       transformQuote: false,
+      appendSpace : false,
       prepend : '',
       append : ''
     });
@@ -26,6 +27,9 @@ module.exports = function (grunt) {
 
       srcFiles.forEach(function (srcFile) {
         var sourceCode = grunt.file.read(srcFile);
+		if (options.appendSpace) {
+			sourceCode = sourceCode.replace(/(\r\n|\n|\r)/gm," \n");
+		}
         var sourceCompiled = compile(sourceCode, srcFile, options.fullname);
 
         if (options.transformQuote) {


### PR DESCRIPTION
Some HTML formatters remove trailing spaces from HTML source files.  This may introduced incorrect HTML code after compiling.  On the other hand, an extra space at the end of each line do not create much problem for the browsers.

For example, in the template contain the following lines (without trailing spaces)

    <input type='text'
        data-slider-min=0
        data-slider-max=1>

After compilation, the HTML become

    <input type='text'data-slider-min=0data-slider-max=1>

But if trailing space is added before compiling, the HTML is correct

    <input type='text' data-slider-min=0 data-slider-max=1>

