### PR TITLE
Allow for optional whitespace preservation

### DIFF
--- a/tasks/dustjs.js
+++ b/tasks/dustjs.js
@@ -26,7 +26,7 @@ module.exports = function (grunt) {
 
       srcFiles.forEach(function (srcFile) {
         var sourceCode = grunt.file.read(srcFile);
-        var sourceCompiled = compile(sourceCode, srcFile, options.fullname);
+        var sourceCompiled = compile(sourceCode, srcFile, options);
 
         if (options.transformQuote) {
             sourceCompiled = sourceCompiled.replace('chk.write("', "chk.write('");
@@ -46,10 +46,16 @@ module.exports = function (grunt) {
     });
   });
 
-  function compile (source, filepath, fullFilename) {
+  function compile (source, filepath, options) {
     var path = require("path"),
         dust = require("dustjs-linkedin"),
+        fullFilename = options.fullname,
+        preserveWhitespace = options.preserveWhitespace,
         name;
+
+    if (preserveWhitespace) {
+      dust.optimizers.format = function(ctx, node) { return node; };
+    }
 
     if (typeof fullFilename === "function") {
       name = fullFilename(filepath);


### PR DESCRIPTION
This would allow for a grunt configuration such as:

```javascript
var path = require("path");

module.exports = function (grunt) {
  //...
  grunt.loadNpmTasks("grunt-dustjs");
  //...

  var config = {
    //...
    dustjs: {},
    //...
  };

  config.dustjs: {
    compile: {
      files: {
        "js/templates.js": ["src/templates/**/*.html"]
      },
      options: {
        preserveWhitespace: true
      }
    }
  },
});
```


This is useful for cases where both `<script>` tags and `markdown` conversions require whitespace.